### PR TITLE
Update peer dependency mini-css-extract-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/azcn2503/cleanup-mini-css-extract-plugin"
   },
   "peerDependencies": {
-    "mini-css-extract-plugin": "^0.9.0",
+    "mini-css-extract-plugin": "^0.9.0 || 1.x || 2.x",
     "webpack": "^4.41.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cleanup-mini-css-extract-plugin",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "main": "index.js",
   "author": "Aaron Cunnington <azcn2503@gmail.com>",
   "license": "MIT",
@@ -10,6 +10,6 @@
   },
   "peerDependencies": {
     "mini-css-extract-plugin": "^0.9.0 || 1.x || 2.x",
-    "webpack": "^4.41.4"
+    "webpack": "^4.41.4 || 5.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cleanup-mini-css-extract-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "author": "Aaron Cunnington <azcn2503@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Version 8 of npm throws an error when installing cleanup-mini-css-extract-plugin and the latest version of mini-css-extract-plugin.  However, cleanup-mini-css-extract does work with versions 1 and 2 of mini-css-extract-plugin.  This proposal simply silences an error that prevents `npm install` for users of npm 8 and above.